### PR TITLE
fix undotree wakeup command

### DIFF
--- a/.vim/init.vim
+++ b/.vim/init.vim
@@ -1074,7 +1074,7 @@ Plug 'preservim/nerdcommenter'
 "Plug 'honza/vim-snippets'
 "Plug 'neoclide/coc-snippets'
 Plug 'jackguo380/vim-lsp-cxx-highlight'
-Plug 'mbbill/undotree', {'on': 'UndoTreeToggle'}
+Plug 'mbbill/undotree', {'on': 'UndotreeToggle'}
 "Plug 'ilyachur/cmake4vim', {'on': ['CMake', 'CMakeBuild', 'CMakeInfo', 'CMakeRun']}
 "Plug 'puremourning/vimspector'
 "Plug 'ctrlpvim/ctrlp.vim', {'on': ['CtrlP']}


### PR DESCRIPTION
[Usage of undotree](https://github.com/mbbill/undotree#usage)
We should use `UndotreeToggle` instead of `UndoTreeToggle` to wakeup a undotree window.