### PR TITLE
fix install nvim scripts bug

### DIFF
--- a/lua/archvim/custom.lua
+++ b/lua/archvim/custom.lua
@@ -9,8 +9,8 @@ end
 if require'archvim.options'.transparent_color then
     vim.cmd [[
     augroup colorscheme_mock
-    autocmd!
-    autocmd ColorScheme * hi Normal guibg=none | hi def link LspInlayHint Comment
+    " autocmd!
+    " autocmd ColorScheme * hi Normal guibg=none | hi def link LspInlayHint Comment
         " \ | hi LspReferenceText guibg=none
         " \ | hi LspReferenceRead guibg=none
         " \ | hi LspReferenceWrite guibg=none
@@ -30,7 +30,8 @@ end
 
 vim.cmd [[
 " silent! colorscheme zephyr
-silent! colorscheme gruvbox
+" silent! colorscheme gruvbox
+silent! colorscheme dawnfox
 ]]
 
 -- More custom options goes here

--- a/lua/archvim/plugins.lua
+++ b/lua/archvim/plugins.lua
@@ -650,6 +650,14 @@ return packer.startup(function (use)
     for _, item in ipairs(plugins) do
         use(item)
     end
+    -- go
+    use "ray-x/go.nvim"
+    use "ray-x/guihua.lua"
+    -- go
+    -- colortheme
+    use "EdenEast/nightfox.nvim" 
+    -- colortheme
+
     if is_packer_bootstrap then
         -- if archvim_predownload == 1 then
         --     local install_path = vim.fn.stdpath('data')..'/site/pack/packer/start/packer.nvim'

--- a/scripts/install_nvim.sh
+++ b/scripts/install_nvim.sh
@@ -34,12 +34,12 @@ if [ "x$(uname -sm)" = "xLinux x86_64" ]; then
     if which snap >/dev/null 2>&1; then
         sudo snap remove nvim || true
     fi
-    test -f ./nvim.appimage || curl -SL https://github.com/neovim/neovim/releases/latest/download/nvim-linux-x86_64.appimage -o ~/.config/nvim/nvim.appimage
+    test -f ./nvim.appimage || curl -SL https://github.com/neovim/neovim/releases/latest/download/nvim-linux-x86_64.appimage -o ./nvim.appimage
     sudo chmod +x ./nvim.appimage
     test -f /usr/bin/nvim && sudo mv /usr/bin/nvim /tmp/.nvim-executable-backup || true
     sudo cp ./nvim.appimage /usr/bin/nvim
     /usr/bin/nvim --version || fix_nvim_appimage
-if [ "x$(uname -sm)" = "xLinux aarch64" ]; then
+elif [ "x$(uname -sm)" = "xLinux aarch64" ]; then
     if which snap >/dev/null 2>&1; then
         sudo snap remove nvim || true
     fi
@@ -65,3 +65,4 @@ else
       sudo snap install nvim
     fi
 fi
+


### PR DESCRIPTION
感谢作者的分享，插件非常好用，该pr是针对在ubuntu22.04在安装nvim时遇到的问题做了修复，实测可以正常安装。
PS：在安装该整合包时，最好需要删除之前的nvim老版本，否则可能会不兼容