### PR TITLE
fix: invert ternary operator logic in 'H' 'L' keymap logic

### DIFF
--- a/.vim/init.vim
+++ b/.vim/init.vim
@@ -399,10 +399,10 @@ imap <C-q> <ESC><C-q>
 tmap <C-q> <ESC><C-q>
 "nnoremap Z :wa!<CR>:qa!<CR>
 "vmap Z <ESC>Z
-nnoremap <silent><expr> H (v:count == 0 ? '^' : '^^' . (v:count == 1 ? (v:count - 1) . 'l' : ''))
-nnoremap <silent><expr> L (v:count == 0 ? '$' : '^$' . (v:count == 1 ? (v:count - 1) . 'h' : ''))
-xnoremap <silent><expr> H (v:count == 0 ? '^' : '^^' . (v:count == 1 ? (v:count - 1) . 'l' : ''))
-xnoremap <silent><expr> L (v:count == 0 ? '$' : '^$' . (v:count == 1 ? (v:count - 1) . 'h' : ''))
+nnoremap <silent><expr> H (v:count != 0 ? '^' : '^^' . (v:count == 1 ? (v:count - 1) . 'l' : ''))
+nnoremap <silent><expr> L (v:count != 0 ? '$' : '^$' . (v:count == 1 ? (v:count - 1) . 'h' : ''))
+xnoremap <silent><expr> H (v:count != 0 ? '^' : '^^' . (v:count == 1 ? (v:count - 1) . 'l' : ''))
+xnoremap <silent><expr> L (v:count != 0 ? '$' : '^$' . (v:count == 1 ? (v:count - 1) . 'h' : ''))
 "nnoremap z zz
 "vnoremap z zz
 "nnoremap <CR> O<ESC>cc<ESC>j

--- a/.vim/init.vim
+++ b/.vim/init.vim
@@ -399,10 +399,10 @@ imap <C-q> <ESC><C-q>
 tmap <C-q> <ESC><C-q>
 "nnoremap Z :wa!<CR>:qa!<CR>
 "vmap Z <ESC>Z
-nnoremap <silent><expr> H (v:count != 0 ? '^' : '^^' . (v:count == 1 ? (v:count - 1) . 'l' : ''))
-nnoremap <silent><expr> L (v:count != 0 ? '$' : '^$' . (v:count == 1 ? (v:count - 1) . 'h' : ''))
-xnoremap <silent><expr> H (v:count != 0 ? '^' : '^^' . (v:count == 1 ? (v:count - 1) . 'l' : ''))
-xnoremap <silent><expr> L (v:count != 0 ? '$' : '^$' . (v:count == 1 ? (v:count - 1) . 'h' : ''))
+nnoremap <silent><expr> H (v:count == 0 ? '^' : '^^' . (v:count != 1 ? (v:count - 1) . 'l' : ''))
+nnoremap <silent><expr> L (v:count == 0 ? '$' : '^$' . (v:count != 1 ? (v:count - 1) . 'h' : ''))
+xnoremap <silent><expr> H (v:count == 0 ? '^' : '^^' . (v:count != 1 ? (v:count - 1) . 'l' : ''))
+xnoremap <silent><expr> L (v:count == 0 ? '$' : '^$' . (v:count != 1 ? (v:count - 1) . 'h' : ''))
 "nnoremap z zz
 "vnoremap z zz
 "nnoremap <CR> O<ESC>cc<ESC>j


### PR DESCRIPTION
在`.vim/init.vim`，'H','L'改键为
```
nnoremap <silent><expr> H (v:count == 0 ? '^' : '^^' . (v:count == 1 ? (v:count - 1) . 'l' : ''))
nnoremap <silent><expr> L (v:count == 0 ? '$' : '^$' . (v:count == 1 ? (v:count - 1) . 'h' : ''))
xnoremap <silent><expr> H (v:count == 0 ? '^' : '^^' . (v:count == 1 ? (v:count - 1) . 'l' : ''))
xnoremap <silent><expr> L (v:count == 0 ? '$' : '^$' . (v:count == 1 ? (v:count - 1) . 'h' : ''))
```
其中三目运算符逻辑判断反了，导致前缀数字不会按预期工作

将其修改为
```
nnoremap <silent><expr> H (v:count == 0 ? '^' : '^^' . (v:count != 1 ? (v:count - 1) . 'l' : ''))
nnoremap <silent><expr> L (v:count == 0 ? '$' : '^$' . (v:count != 1 ? (v:count - 1) . 'h' : ''))
xnoremap <silent><expr> H (v:count == 0 ? '^' : '^^' . (v:count != 1 ? (v:count - 1) . 'l' : ''))
xnoremap <silent><expr> L (v:count == 0 ? '$' : '^$' . (v:count != 1 ? (v:count - 1) . 'h' : ''))
```
